### PR TITLE
Stop corpses of flying creatures from moving

### DIFF
--- a/src/game/PointMovementGenerator.cpp
+++ b/src/game/PointMovementGenerator.cpp
@@ -137,6 +137,10 @@ void EffectMovementGenerator::Finalize(Unit& unit)
         else
             unit.GetMotionMaster()->Initialize();
     }
+    else if (!unit.IsAlive())
+    {
+        unit.GetMotionMaster()->MoveIdle();
+    }
 
     if (unit.ToCreature()->AI())
         unit.ToCreature()->AI()->MovementInform(EFFECT_MOTION_TYPE, m_Id);


### PR DESCRIPTION
When units die the Unit::setDeathState sets their movement type to Idle. But for flying creatures this is immediately replaced by a MoveFall call. So when the corpse of a flying creature hits the ground, the MoveFall movement will finish and the MotionMaster will reset itself to the default state. If the default state is for example a RandomMovementGenerator, this will cause the corpse to move. An example of this happening can be seen after killing Nether Drakes (18877) in Netherstorm.
