### PR TITLE
[Core/Battlegrounds] Fix #1310 - Bad distance calculations

### DIFF
--- a/sql/updates/world/2016_06_15_battlegrounds.sql
+++ b/sql/updates/world/2016_06_15_battlegrounds.sql
@@ -1,0 +1,12 @@
+-- Update maximum start distance radius values
+
+-- av 100 -> 150 (max walkable ~120)
+update battleground_template set StartMaxDist = 150 where id = 1;
+
+-- wsg 75 -> 45 (max walkable ~40)
+update battleground_template set StartMaxDist = 45 where id = 2;
+
+-- ab left intact, 75 is OK (max walkable is ~70)
+
+-- eos 75 -> 10 (max walkable is ~5)
+update battleground_template set StartMaxDist = 10 where id = 7;

--- a/src/game/Battleground.cpp
+++ b/src/game/Battleground.cpp
@@ -1936,7 +1936,7 @@ inline void Battleground::_CheckSafePositions(uint32 diff)
             {
                 pos = player->GetPosition();
                 GetTeamStartLoc(player->GetBGTeam(), x, y, z, o);
-                if (pos.GetExactDistSq(x, y, z) > maxDist)
+                if (!pos.IsInDist2d(x, y, maxDist))
                 {
                     sLog.outDebug("BATTLEGROUND: Sending %s back to start location (map: %u) (possible exploit)", player->GetName(), GetMapId());
                     player->TeleportTo(GetMapId(), x, y, z, o);


### PR DESCRIPTION
- When you entered bg you were teleported to the start location over and
  over again until the bg started
- The feature was introduced in 160e3c6 but there was an error in
  formula - distance was calculated in square yards but compared to
  yards. This was fixed and also database values were changed to fit for
  each battleground.
